### PR TITLE
添加 #import <Foundation/Foundation.h>

### DIFF
--- a/Sources/HWPanModal.h
+++ b/Sources/HWPanModal.h
@@ -4,6 +4,7 @@
 //
 //  Created by heath wang on 2019/4/30.
 //
+#import <Foundation/Foundation.h>
 
 //! Project version number for HWPanModal.
 FOUNDATION_EXPORT double HWPanModalVersionNumber;


### PR DESCRIPTION
不添加的话，在 XCode 13.2.1 下，开启 useframeworks  时，编译报错：
unknown type name 'FOUNDATION_EXPORT'