### PR TITLE
Add API `- (void)didEndRespondToPanModalGestureRecognizer:(nonnull UIPanGestureRecognizer *)panGestureRecognizer`

### DIFF
--- a/Sources/Mediator/HWPanModalPresentableHandler.m
+++ b/Sources/Mediator/HWPanModalPresentableHandler.m
@@ -290,6 +290,7 @@ static NSString *const kScrollViewKVOContentOffsetKey = @"contentOffset";
             }
         }
     }
+	[self.presentable didEndRespondToPanModalGestureRecognizer:panGestureRecognizer];
 }
 
 - (void)handleDragUpState:(PresentationState)state {

--- a/Sources/Presentable/HWPanModalPresentable.h
+++ b/Sources/Presentable/HWPanModalPresentable.h
@@ -321,6 +321,12 @@ typedef NS_ENUM(NSInteger, PresentingViewControllerAnimationStyle) {
 - (void)didRespondToPanModalGestureRecognizer:(nonnull UIPanGestureRecognizer *)panGestureRecognizer;
 
 /**
+ * 内部处理完成拖动操作后触发此回调，此时view frame可能已经变化。
+ * Framework has did finish logic for GestureRecognizer delegate. It will call many times when you darg.
+ */
+- (void)didEndRespondToPanModalGestureRecognizer:(nonnull UIPanGestureRecognizer *)panGestureRecognizer;
+
+/**
  * 是否优先执行dismiss拖拽手势，当存在panScrollable的情况下，如果此方法返回YES，则
  * dismiss手势生效，scrollView本身的滑动则不再生效。也就是说可以拖动Controller view，而scrollView没法拖动了。
  *

--- a/Sources/Presentable/UIViewController+PanModalDefault.m
+++ b/Sources/Presentable/UIViewController+PanModalDefault.m
@@ -203,6 +203,10 @@
     
 }
 
+- (void)didEndRespondToPanModalGestureRecognizer:(nonnull UIPanGestureRecognizer *)panGestureRecognizer {
+	
+}
+
 - (BOOL)shouldPrioritizePanModalGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer {
 	return NO;
 }

--- a/Sources/View/PanModal/HWPanModalContentView.m
+++ b/Sources/View/PanModal/HWPanModalContentView.m
@@ -257,6 +257,10 @@
     
 }
 
+- (void)didEndRespondToPanModalGestureRecognizer:(nonnull UIPanGestureRecognizer *)panGestureRecognizer {
+	
+}
+
 - (BOOL)shouldPrioritizePanModalGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer {
     return NO;
 }


### PR DESCRIPTION
当`presentable`可以左右滑动时，下滑会同时触发`presentable`左右滑动，或者`presentable`左右滑动时也会触发下拉，体验不太好。

我在子类的`shouldRespondToPanModalGestureRecognizer`里做了处理。需要添加这个`didEndRespondToPanModalGestureRecognizer`API。
也可以考虑把这个逻辑写进`HWPanModalPresentableHandler`
```swift
override func shouldRespond(toPanModalGestureRecognizer panGestureRecognizer: UIPanGestureRecognizer) -> Bool {
    if let respond = self.panView?.shouldRespond(toPanModalGestureRecognizer: panGestureRecognizer), !respond {
        return respond
    }
    if let scrollView = panScrollable(), scrollView.isScrollEnabled {
        if !scrollView.isDragging, scrollView.isTracking, scrollView.contentOffsetY == 0 {
            // 还没有开始滚动，但已经触发了scrollView的滚动。此时若是下拉，则认为是关闭弹窗
            let velocity = panGestureRecognizer.velocity(in: scrollView)
            let 是否下拉 = velocity.y > 0 && velocity.y > abs(velocity.x)
            if 是否下拉 {
                disableScroll = true
                scrollView.isScrollEnabled = false
            }
            return 是否下拉
        }
        return !(scrollView.isScrolling)
    }
    return true
}

public override func didEndRespond(toPanModalGestureRecognizer panGestureRecognizer: UIPanGestureRecognizer) {
    if disableScroll {
        disableScroll = false
        panScrollable()?.isScrollEnabled = true
    }
}
```