### PR TITLE
fix dimmedView not updating in some cases

### DIFF
--- a/Sources/Controller/HWPanModalPresentationController.m
+++ b/Sources/Controller/HWPanModalPresentationController.m
@@ -83,11 +83,18 @@
 	}
 
 	__weak  typeof(self) wkSelf = self;
+	__block BOOL isAnimated = NO;
 	[self.presentedViewController.transitionCoordinator animateAlongsideTransition:^(id <UIViewControllerTransitionCoordinatorContext> context) {
 		wkSelf.backgroundView.dimState = DimStateMax;
 		[wkSelf.presentedViewController setNeedsStatusBarAppearanceUpdate];
+		isAnimated = YES;
     } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        
+		if (!isAnimated) {
+			/// In some cases, for example, present a `hw` when a navigation controller is pushing a new vc, `animateAlongsideTransition` will not call.
+			/// If not called, call it here.
+			wkSelf.backgroundView.dimState = DimStateMax;
+			[wkSelf.presentedViewController setNeedsStatusBarAppearanceUpdate];
+		}
         if ([[wkSelf presentable] allowsTouchEventsPassingThroughTransitionView]) {
             // hack TransitionView
             [wkSelf.containerView setValue:@(YES) forKey:@"ignoreDirectTouchEvents"];


### PR DESCRIPTION
在`navigationVC`上`present`一个`hw`，如果`navigationVC`正在push动画中，这里的`animateAlongsideTransition`不会执行，只会执行`completion`
https://github.com/HeathWang/HWPanModal/blob/c907c655e5169005aa0c2058a65a6c7eebbe480f/Sources/Controller/HWPanModalPresentationController.m#L86