### PR TITLE
Fix: iPad Resize Window

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -37,12 +37,19 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>

--- a/HWPanModal.xcodeproj/project.pbxproj
+++ b/HWPanModal.xcodeproj/project.pbxproj
@@ -955,7 +955,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SwiftDemo/Pods-SwiftDemo-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HWPanModal-iOS10.0/HWPanModal.framework",
+				"${BUILT_PRODUCTS_DIR}/HWPanModal/HWPanModal.framework",
 				"${BUILT_PRODUCTS_DIR}/SnapKit/SnapKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -975,7 +975,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-HWPanModalDemo/Pods-HWPanModalDemo-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HWPanModal-iOS8.0/HWPanModal.framework",
+				"${BUILT_PRODUCTS_DIR}/HWPanModal/HWPanModal.framework",
 				"${BUILT_PRODUCTS_DIR}/MJRefresh/MJRefresh.framework",
 				"${BUILT_PRODUCTS_DIR}/Masonry/Masonry.framework",
 			);
@@ -1341,7 +1341,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = K4R83Q5KV5;
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.heath.wang.HWPanModalDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1359,7 +1359,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = K4R83Q5KV5;
 				INFOPLIST_FILE = "$(SRCROOT)/Demo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.heath.wang.HWPanModalDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Podfile
+++ b/Podfile
@@ -5,14 +5,22 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'HWPanModalDemo' do
-  platform :ios, '8.0'
+  platform :ios, '11.0'
   pod 'Masonry'
   pod 'MJRefresh'
   pod 'HWPanModal', :path => './'
 end
 
 target 'SwiftDemo' do
-  platform :ios, '10.0'
+  platform :ios, '11.0'
   pod 'SnapKit', '~> 5.0.0'
   pod 'HWPanModal', :path => './'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "11.0"
+    end
+  end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - HWPanModal (0.9.7)
+  - HWPanModal (0.9.8)
   - Masonry (1.1.0)
   - MJRefresh (3.5.0)
   - SnapKit (5.0.1)
@@ -21,11 +21,11 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  HWPanModal: 2340d953661dbeadd1f041cde9e059c0704c873a
+  HWPanModal: 6951685ca7bdf147ff8a68e7d93d61f08a06dead
   Masonry: 678fab65091a9290e40e2832a55e7ab731aad201
   MJRefresh: 6afc955813966afb08305477dd7a0d9ad5e79a16
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
 
-PODFILE CHECKSUM: 3046bfffa65a16097d4e0ee1bb220fa9859f7067
+PODFILE CHECKSUM: 1c9e6698fa3248dfb5a8e1596a59962a50580f41
 
 COCOAPODS: 1.11.3

--- a/SwiftDemo/Info.plist
+++ b/SwiftDemo/Info.plist
@@ -29,7 +29,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
1. 修复Demo在Xcode15中的报错
```
SDK does not contain 'libarclite' at the path '/Applications/Xcode-15.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphonesimulator.a'; try increasing the minimum deployment target
```

2. Demo支持iPad的窗口缩放功能

3. 修复iPad上窗口缩放时，HWPanModalContentView不会跟随窗口变化大小 #149  
