### PR TITLE
fix: replace deprecated APIs for iOS 13+ UIScene compatibility

### DIFF
--- a/HWPanModal.podspec
+++ b/HWPanModal.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'HWPanModal'
-  s.version          = '0.9.10'
+  s.version          = '1.0.1'
   s.summary          = 'HWPanModal is used to present controller and drag to dismiss.'
 
 # This description is used to generate tags and improve search results.

--- a/Sources/Animator/PresentingVCAnimation/HWPageSheetPresentingAnimation.m
+++ b/Sources/Animator/PresentingVCAnimation/HWPageSheetPresentingAnimation.m
@@ -13,7 +13,7 @@
     NSTimeInterval duration = [context transitionDuration];
     UIViewController *fromVC = [context viewControllerForKey:UITransitionContextFromViewControllerKey];
     [UIView animateWithDuration:duration delay:0 usingSpringWithDamping:0.9 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-        CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+        CGFloat statusBarHeight = fromVC.view.window.windowScene.statusBarManager.statusBarFrame.size.height;
         CGFloat scale = 1 - statusBarHeight * 2 / CGRectGetHeight(fromVC.view.bounds);
         fromVC.view.transform = CGAffineTransformMakeScale(scale, scale);
     } completion:^(BOOL finished) {

--- a/Sources/Animator/PresentingVCAnimation/HWShoppingCartPresentingAnimation.m
+++ b/Sources/Animator/PresentingVCAnimation/HWShoppingCartPresentingAnimation.m
@@ -13,7 +13,7 @@
 
     NSTimeInterval duration = [context transitionDuration];
     UIViewController *fromVC = [context viewControllerForKey:UITransitionContextFromViewControllerKey];
-    CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+    CGFloat statusBarHeight = fromVC.view.window.windowScene.statusBarManager.statusBarFrame.size.height;
     CGFloat scale = 1 - statusBarHeight * 2 / CGRectGetHeight(fromVC.view.bounds);
     [UIView animateWithDuration:duration * 0.4 delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
         CATransform3D tran = CATransform3DIdentity;

--- a/Sources/Mediator/HWPanModalPresentableHandler.m
+++ b/Sources/Mediator/HWPanModalPresentableHandler.m
@@ -433,7 +433,15 @@ static NSString *const kScrollViewKVOContentOffsetKey = @"contentOffset";
         if (![self.presentable shouldAutoSetPanScrollContentInset]) return;
         
         UIEdgeInsets insets1 = scrollView.contentInset;
-        CGFloat bottomLayoutOffset = [UIApplication sharedApplication].keyWindow.rootViewController.bottomLayoutGuide.length;
+        UIWindow *keyWindow = nil;
+        for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+            for (UIWindow *w in ((UIWindowScene *)scene).windows) {
+                if (w.isKeyWindow) { keyWindow = w; break; }
+            }
+            if (keyWindow) break;
+        }
+        CGFloat bottomLayoutOffset = keyWindow.safeAreaInsets.bottom;
         /*
          * If scrollView has been set contentInset, and bottom is NOT zero, we won't change it.
          * If contentInset.bottom is zero, set bottom = bottomLayoutOffset

--- a/Sources/Presentable/UIViewController+LayoutHelper.m
+++ b/Sources/Presentable/UIViewController+LayoutHelper.m
@@ -11,21 +11,22 @@
 
 @implementation UIViewController (LayoutHelper)
 
-- (CGFloat)topLayoutOffset {
-    if (@available(iOS 11, *)) {
-        return [UIApplication sharedApplication].keyWindow.safeAreaInsets.top;
-    } else {
-        return [UIApplication sharedApplication].keyWindow.rootViewController.topLayoutGuide.length;
+- (UIWindow *)hw_keyWindow {
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+            if (window.isKeyWindow) return window;
+        }
     }
-	
+    return nil;
+}
+
+- (CGFloat)topLayoutOffset {
+    return [self hw_keyWindow].safeAreaInsets.top;
 }
 
 - (CGFloat)bottomLayoutOffset {
-    if (@available(iOS 11, *)) {
-        return [UIApplication sharedApplication].keyWindow.safeAreaInsets.bottom;
-    } else {
-        return [UIApplication sharedApplication].keyWindow.rootViewController.bottomLayoutGuide.length;
-    }
+    return [self hw_keyWindow].safeAreaInsets.bottom;
 }
 
 - (HWPanModalPresentationController *)hw_presentedVC {
@@ -118,7 +119,8 @@
 		{
 			[self.view layoutIfNeeded];
 
-            CGSize targetSize = CGSizeMake(self.hw_presentedVC.containerView ? self.hw_presentedVC.containerView.bounds.size.width : [UIScreen mainScreen].bounds.size.width, UILayoutFittingCompressedSize.height);
+            CGFloat screenWidth = [self hw_keyWindow].bounds.size.width ?: UIScreen.mainScreen.bounds.size.width;
+            CGSize targetSize = CGSizeMake(self.hw_presentedVC.containerView ? self.hw_presentedVC.containerView.bounds.size.width : screenWidth, UILayoutFittingCompressedSize.height);
             CGFloat intrinsicHeight = [self.view systemLayoutSizeFittingSize:targetSize].height;
 			return self.bottomYPos - (intrinsicHeight + self.bottomLayoutOffset);
 		}

--- a/Sources/View/PanModal/HWPanModalContainerView.m
+++ b/Sources/View/PanModal/HWPanModalContainerView.m
@@ -327,7 +327,7 @@
 
     // 提高性能
     view.layer.shouldRasterize = YES;
-    view.layer.rasterizationScale = [UIScreen mainScreen].scale;
+    view.layer.rasterizationScale = UITraitCollection.currentTraitCollection.displayScale;
 }
 
 - (void)resetRoundedCornersToView:(UIView *)view {

--- a/Sources/View/PanModal/HWPanModalContentView.m
+++ b/Sources/View/PanModal/HWPanModalContentView.m
@@ -358,7 +358,8 @@
         case PanModalHeightTypeIntrinsic: {
             [self layoutIfNeeded];
 
-            CGSize targetSize = CGSizeMake(self.containerView ? self.containerView.bounds.size.width : [UIScreen mainScreen].bounds.size.width, UILayoutFittingCompressedSize.height);
+            CGFloat screenWidth = self.window.bounds.size.width ?: UIScreen.mainScreen.bounds.size.width;
+            CGSize targetSize = CGSizeMake(self.containerView ? self.containerView.bounds.size.width : screenWidth, UILayoutFittingCompressedSize.height);
             CGFloat intrinsicHeight = [self systemLayoutSizeFittingSize:targetSize].height;
             return self.bottomYPos - (intrinsicHeight + self.bottomLayoutOffset);
         }


### PR DESCRIPTION
- Replace `[UIApplication sharedApplication].keyWindow` with Scene-safe `hw_keyWindow` helper using `connectedScenes` traversal
- Replace `bottomLayoutGuide.length` / `topLayoutGuide.length` with `safeAreaInsets` (iOS 11+, safe for current deployment target)
- Replace `[UIApplication sharedApplication].statusBarFrame` with `windowScene.statusBarManager.statusBarFrame`
- Replace `beginAnimations/commitAnimations` with block-based `animateWithDuration:delay:options:animations:completion:`
- Replace `[UIApplication sharedApplication].windows` fallback with `connectedScenes` only in `findKeyWindow`
- Replace `[UIScreen mainScreen]` with window-based bounds where applicable

These deprecated APIs return nil/zero under UIScene lifecycle (mandatory in iOS 27), causing layout issues in pan modal presentation.